### PR TITLE
Correctly recognize full file paths returned from nlist command

### DIFF
--- a/lib/paperclip/storage/ftp/server.rb
+++ b/lib/paperclip/storage/ftp/server.rb
@@ -24,7 +24,7 @@ module Paperclip
 
         def file_exists?(path)
           pathname = Pathname.new(path)
-          connection.nlst(pathname.dirname.to_s).include?(pathname.basename.to_s)
+          connection.nlst(pathname.dirname.to_s).map { |f| File.basename f }.include?(pathname.basename.to_s)
         end
 
         def get_file(remote_file_path, local_file_path)

--- a/spec/paperclip/storage/ftp/server_spec.rb
+++ b/spec/paperclip/storage/ftp/server_spec.rb
@@ -31,6 +31,12 @@ describe Paperclip::Storage::Ftp::Server do
       server.file_exists?("/files/original/foo.jpg").should be_true
     end
 
+    it "recognizes complete file paths correctly" do
+      server.connection = double("connection")
+      server.connection.should_receive(:nlst).with("/files/original").and_return(["/files/original/foo.jpg"])
+      server.file_exists?("/files/original/foo.jpg").should be_true
+    end
+
     it "returns false if the file does not exist on the server" do
       server.connection = double("connection")
       server.connection.should_receive(:nlst).with("/files/original").and_return([])


### PR DESCRIPTION
Apparently some FTP servers return "/foo/bar/baz.jpg" and others just "baz.jpg" when doing an NLIST command.  This should handle that correctly.
