### PR TITLE
Make sure Server#port isn't nil

### DIFF
--- a/lib/paperclip/storage/ftp/server.rb
+++ b/lib/paperclip/storage/ftp/server.rb
@@ -6,8 +6,8 @@ module Paperclip
     module Ftp
       class Server
 
-        attr_accessor :host, :user, :password, :port
-        attr_writer   :connection
+        attr_accessor :host, :user, :password
+        attr_writer   :connection, :port
 
         def self.default_options
           {
@@ -48,6 +48,10 @@ module Paperclip
             connection.login(user, password)
             connection
           end
+        end
+
+        def port
+          @port || Net::FTP::FTP_PORT
         end
 
         def mkdir_p(dirname)


### PR DESCRIPTION
When @port is nil Net::FTP will throw a Errno::ECONNREFUSED.  This fixes it.
