### PR TITLE
Make sure Server#port isn't nil

### DIFF
--- a/lib/paperclip/storage/ftp/server.rb
+++ b/lib/paperclip/storage/ftp/server.rb
@@ -6,8 +6,8 @@ module Paperclip
     module Ftp
       class Server
 
-        attr_accessor :host, :user, :password, :port
-        attr_writer   :connection
+        attr_accessor :host, :user, :password
+        attr_writer   :connection, :port
 
         def self.default_options
           {
@@ -48,6 +48,10 @@ module Paperclip
             connection.login(user, password)
             connection
           end
+        end
+
+        def port
+          @port || Net::FTP::FTP_PORT
         end
 
         def mkdir_p(dirname)

--- a/spec/paperclip/storage/ftp/server_spec.rb
+++ b/spec/paperclip/storage/ftp/server_spec.rb
@@ -19,7 +19,7 @@ describe Paperclip::Storage::Ftp::Server do
     end
 
     it "sets a default port" do
-      server = Paperclip::Storage::Ftp::Server.new
+      server = Paperclip::Storage::Ftp::Server.new(:port => nil)
       server.port.should == Net::FTP::FTP_PORT
     end
   end


### PR DESCRIPTION
If you explicitly initialize the server with :port => nil the default port isn't used making it unable to connect.  This fixes that.
