### PR TITLE
Rescue FTPPermError exception during file_exists? in the Server

### DIFF
--- a/lib/paperclip/storage/ftp/server.rb
+++ b/lib/paperclip/storage/ftp/server.rb
@@ -50,7 +50,7 @@ module Paperclip
         def file_exists?(path)
           pathname = Pathname.new(path)
           connection.nlst(pathname.dirname.to_s).map{|f| File.basename f }.include?(pathname.basename.to_s)
-        rescue Net::FTPTempError
+        rescue Net::FTPTempError, Net::FTPPermError
           false
         end
 

--- a/spec/paperclip/storage/ftp/server_spec.rb
+++ b/spec/paperclip/storage/ftp/server_spec.rb
@@ -47,6 +47,11 @@ describe Paperclip::Storage::Ftp::Server do
       server.connection.should_receive(:nlst).with("/files/original").and_raise(Net::FTPTempError)
       server.file_exists?("/files/original/foo.jpg").should be false
     end
+
+    it "returns false if the ftp server responds with a FTPPermError" do
+      server.connection.should_receive(:nlst).with("/files/original").and_raise(Net::FTPPermError)
+      server.file_exists?("/files/original/foo.jpg").should be false
+    end
   end
 
   context "#get_file" do


### PR DESCRIPTION
Hi,

The FTP server used by me, when there is no file/directory present - returns:
`550 NLST command failed: No such file or directory.`
and this is the `Net::FTPPermError` exception.

I need this change to use your gem in my project, currently I'm stick to my fork. 

Thanks
Michal
