### PR TITLE
Ignore ftp error when deleting an non-existing file

### DIFF
--- a/lib/paperclip/storage/ftp/server.rb
+++ b/lib/paperclip/storage/ftp/server.rb
@@ -66,6 +66,8 @@ module Paperclip
 
         def delete_file(remote_file_path)
           connection.delete(remote_file_path)
+        rescue Net::FTPPermError
+          # This happens if the file is already deleted
         end
 
         def rmdir_p(dir_path)

--- a/spec/paperclip/storage/ftp/server_spec.rb
+++ b/spec/paperclip/storage/ftp/server_spec.rb
@@ -86,6 +86,12 @@ describe Paperclip::Storage::Ftp::Server do
       server.connection.should_receive(:delete).with("/files/original.jpg")
       server.delete_file("/files/original.jpg")
     end
+
+    it 'rescues from Net::FTPPermError' do
+      server.connection.should_receive(:delete).with('/files/original.jpg')
+        .and_raise Net::FTPPermError
+      expect { server.delete_file('/files/original.jpg') }.to_not raise_error
+    end
   end
 
   context "#rmdir_p" do


### PR DESCRIPTION
We (@events) have issues with race condition where one file is updated (deleted) by two processors. Failing to delete a non existing file might not a be a very bad thing...